### PR TITLE
Changes to home, setup, and ops labs

### DIFF
--- a/workshop/content/100-setup/1-environment.adoc
+++ b/workshop/content/100-setup/1-environment.adoc
@@ -47,9 +47,9 @@ az version
 [source,texinfo]
 ----
 {
-  "azure-cli": "2.49.0",
-  "azure-cli-core": "2.49.0",
-  "azure-cli-telemetry": "1.0.8",
+  "azure-cli": "2.51.0",
+  "azure-cli-core": "2.51.0",
+  "azure-cli-telemetry": "1.1.0",
   "extensions": {}
 }
 ----

--- a/workshop/content/200-ops/day2/1-upgrades.adoc
+++ b/workshop/content/200-ops/day2/1-upgrades.adoc
@@ -40,7 +40,7 @@ The Managed Upgrade Operator has been created to manage the orchestration of aut
 
 Whilst the operator's job is to invoke a cluster upgrade, it does not perform any activities of the cluster upgrade process itself.
 
-This remains the responsibility of OpenShift itself.
+This remains the responsibility of OpenShift.
 
 The operator's goal is to satisfy the operating conditions that a managed cluster must hold, both pre- and post-invocation of the cluster upgrade.
 
@@ -120,7 +120,7 @@ oc -n openshift-managed-upgrade-operator get \
 [source,text,options=nowrap]
 ----
 NAME                     DESIRED_VERSION   PHASE   STAGE   STATUS   REASON   MESSAGE
-managed-upgrade-config   4.11.41
+managed-upgrade-config   4.11.45
 ----
 
 *Congratulations!*
@@ -142,12 +142,12 @@ In this scenario to upgrade your cluster from version 4.11.0 to 4.12.15, you mus
 
 * https://learn.microsoft.com/en-us/azure/openshift/howto-upgrade[Upgrade an Azure Red Hat OpenShift cluster]
 * https://learn.microsoft.com/en-us/azure/openshift/howto-upgrade#scheduling-individual-upgrades-using-the-managed-upgrade-operator[Scheduling individual upgrades using the managed-upgrade-operator]
-* https://docs.openshift.com/container-platform/4.11/updating/understanding-openshift-updates.html#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
+* https://docs.openshift.com/container-platform/4.13/updating/understanding_updates/intro-to-updates.html#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
 
-=== Summary and Next Steps
+=== Summary
 
 Here you learned:
 
 * All upgrades are monitored and managed by the ARO SRE Team
-* Use the OpenShift Web Console or the Managed Upgrade Operator to schedule an upgrade for your ARO cluster
-* Explore the OpenShift Upgrade Graph Tool to see available upgrade paths
+* How to use the OpenShift Web Console or the Managed Upgrade Operator to schedule an upgrade for your ARO cluster
+* How to explore the OpenShift Upgrade Graph Tool to see available upgrade paths

--- a/workshop/content/200-ops/day2/2-scaling-nodes.adoc
+++ b/workshop/content/200-ops/day2/2-scaling-nodes.adoc
@@ -6,8 +6,8 @@ Many of these changes are done using MachineSets. MachineSets ensure that a spec
 
 Here are some of the advantages of using ARO MachineSets to manage the size of your cluster
 
-* Scalability - MachineSets enables horizontal scaling of your cluster. It can easily add or remove worker to handle the changes in workload. This flexibility ensures that your cluster can dynamically scale to meet the needs of your applications
-* Infrastructure Diversity - MachineSets allow you to provision worker nodes of different instance type. This enables you you leverage the best kind of instance family for different workloads.
+* Scalability - MachineSets enables horizontal scaling of your cluster. It can easily add or remove workers to handle the changes in workload. This flexibility ensures that your cluster can dynamically scale to meet the needs of your applications.
+* Infrastructure Diversity - MachineSets allow you to provision worker nodes of different instance type. This enables you to leverage the best kind of instance family for different workloads.
 * Integration with Cluster Autoscaler - MachineSets seamlessly integrate with the Cluster Autoscaler feature, which automatically adjusts the number of worker nodes based on the current demand. This integration ensures efficient resource utilization by scaling the cluster up or down as needed, optimizing costs and performance.
 
 image:../../media/scale_machinesets.png[scale_machinesets]
@@ -163,5 +163,5 @@ You've successfully scaled your cluster up and back down to three nodes.
 
 Here you learned how to:
 
-* Scaling an existing MachineSet up to add more nodes to the cluster
-* Scaling your MachineSet down to remove worker nodes from the cluster
+* Scale an existing MachineSet up to add more nodes to the cluster
+* Scale your MachineSet down to remove worker nodes from the cluster

--- a/workshop/content/200-ops/day2/3-autoscaling.adoc
+++ b/workshop/content/200-ops/day2/3-autoscaling.adoc
@@ -285,7 +285,7 @@ You've successfully demonstrated cluster autoscaling.
 
 == Summary
 
-Here you learned:
+Here you learned how to:
 
 * Create and configure a machine autoscaler
 * Deploy an application on the cluster and watch the cluster autoscaler scale your cluster to support the increased workload

--- a/workshop/content/200-ops/day2/4-labels.adoc
+++ b/workshop/content/200-ops/day2/4-labels.adoc
@@ -95,7 +95,7 @@ Pending that your output shows one or more node(s), this demonstrates that our M
 == Deploy an app to the labeled nodes
 
 Now that we've successfully labeled our nodes, let's deploy a workload to demonstrate app placement using `nodeSelector`.
-This should force our app to only our labeled nodes.
+This should force our app to deploy only on labeled nodes.
 
 . First, let's create a namespace (also known as a project in OpenShift).
 To do so, run the following command:
@@ -120,7 +120,8 @@ to build a new example application in Ruby. Or use kubectl to deploy a simple Ku
 ----
 
 . Next, let's deploy our application and associated resources that will target our labeled nodes.
-To do so, run the following command:
+Notice how we added the `nodeSelector` to the specification of our Deployment to do this.
+Run the following command:
 +
 [source,sh,role=execute]
 ----
@@ -250,7 +251,8 @@ You've successfully demonstrated the ability to label nodes and target those nod
 
 == Summary
 
-Here you learned:
+Here you learned how to:
 
-* Set label for the MachineSets.
-* Deploy an application on nodes with certain label
+* Set labels on new nodes in a MachineSet
+* Set labels on existing nodes in a MachineSet
+* Deploy an application on nodes with a certain label

--- a/workshop/content/200-ops/day2/5-observability.adoc
+++ b/workshop/content/200-ops/day2/5-observability.adoc
@@ -279,6 +279,13 @@ REVISION: 1
 TEST SUITE: None
 ----
 
+. Wait until Grafana has successfully deployed. Run the following command:
++
+[source,sh,role=execute]
+---
+oc -n custom-logging rollout status deploy grafana-deployment
+---
+
 . Next, let's ensure that we can access Grafana. To do so, we should fetch its route and try browsing to it with your web browser. To grab the route, run the following command:
 +
 [source,sh,role=execute]
@@ -511,12 +518,13 @@ data:
 EOF
 ----
 
-*Congratulations*
+*Congratulations!*
+
 Your cluster is now configured to allow custom metrics.
 
 == Summary
 
 Here you learned how to:
 
-* Configured metrics and log forwarding to Azure Files.
-* View the metrics and logs in a Grafana dashboard.
+* Configure metrics and log forwarding to Azure Files
+* View the metrics and logs in a Grafana dashboard

--- a/workshop/content/200-ops/idp/1a-configure-aad.adoc
+++ b/workshop/content/200-ops/idp/1a-configure-aad.adoc
@@ -9,11 +9,11 @@ https://azure.microsoft.com/en-us/products/active-directory[Azure Active Directo
 
 As part of the Access Your Cluster page, we utilized a temporary cluster-admin user using the `az aro list-credentials` command. This uses a local identity provider to allow you to access the cluster. In this section of the workshop, we'll configure Azure Active Directory as the cluster identity provider in your ARO cluster.
 
-Your ARO cluster has a built-in OAuth server. Developers and administrators do not really directly interact with the OAuth server itself, but instead interact with an external identity provider (such as Azure Active Directory) which is brokered by the OAuth server in the cluster. To learn more about cluster authentication, visit the https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html[Red Hat documentation for identity provider configuration] and the https://learn.microsoft.com/en-us/azure/openshift/configure-azure-ad-cli[Microsoft documentation for configuring Azure Active Directory authentication for ARO].
+Your ARO cluster has a built-in OAuth server. Developers and administrators do not really directly interact with the OAuth server itself, but instead interact with an external identity provider (such as Azure Active Directory) which is brokered by the OAuth server in the cluster. 
 
 The following diagram illustrates the ARO authentication process for a cluster configured with Azure Active Directory.
 
-image:../../media/aro_idp_aad.png[Flow chart illustrating the ARO authentication process for a cluster configured with Azure Active Directory]{ align=center }
+image:../../media/aro_idp_aad.png[Flow chart illustrating the ARO authentication process for a cluster configured with Azure Active Directory]
 
 To learn more about cluster authentication, visit the https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html[Red Hat documentation for identity provider configuration] and the https://learn.microsoft.com/en-us/azure/openshift/configure-azure-ad-cli[Microsoft documentation for configuring Azure Active Directory authentication for ARO].
 

--- a/workshop/content/200-ops/idp/1b-explore-aad.adoc
+++ b/workshop/content/200-ops/idp/1b-explore-aad.adoc
@@ -9,11 +9,11 @@ https://azure.microsoft.com/en-us/products/active-directory[Azure Active Directo
 
 As part of the Access Your Cluster page, we utilized a temporary cluster-admin user using the `az aro list-credentials` command. This uses a local identity provider to allow you to access the cluster. In this section of the workshop, we'll configure Azure Active Directory as the cluster identity provider in your ARO cluster.
 
-Your ARO cluster has a built-in OAuth server. Developers and administrators do not really directly interact with the OAuth server itself, but instead interact with an external identity provider (such as Azure Active Directory) which is brokered by the OAuth server in the cluster. To learn more about cluster authentication, visit the https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html[Red Hat documentation for identity provider configuration] and the https://learn.microsoft.com/en-us/azure/openshift/configure-azure-ad-cli[Microsoft documentation for configuring Azure Active Directory authentication for ARO].
+Your ARO cluster has a built-in OAuth server. Developers and administrators do not really directly interact with the OAuth server itself, but instead interact with an external identity provider (such as Azure Active Directory) which is brokered by the OAuth server in the cluster. 
 
 The following diagram illustrates the ARO authentication process for a cluster configured with Azure Active Directory.
 
-image:../../assets/images/aro_idp_aad.png[Flow chart illustrating the ARO authentication process for a cluster configured with Azure Active Directory]{ align=center }
+image:../../media/aro_idp_aad.png[Flow chart illustrating the ARO authentication process for a cluster configured with Azure Active Directory]
 
 To learn more about cluster authentication, visit the https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html[Red Hat documentation for identity provider configuration] and the https://learn.microsoft.com/en-us/azure/openshift/configure-azure-ad-cli[Microsoft documentation for configuring Azure Active Directory authentication for ARO].
 

--- a/workshop/content/home.adoc
+++ b/workshop/content/home.adoc
@@ -1,10 +1,10 @@
 = Building a Modern Application Platform with Azure & ARO 
 
-Welcome to the Building a Modern Application Platform workshop. In this workshop you will learn the building blocks of modern application platform and leverage Microsoft Azure and  Azure Red Hat OpenShift (ARO) to build a modern application platform. 
+Welcome to the Building a Modern Application Platform workshop. In this workshop you will learn the building blocks of a modern application platform and leverage Microsoft Azure and  Azure Red Hat OpenShift (ARO) to build a modern application platform. 
 
 https://azure.microsoft.com/en-us/services/openshift/[Azure Red Hat OpenShift] is a fully managed Red Hat OpenShift service in Azure that is jointly engineered and supported by Microsoft and Red Hat.
 
-*Who this workshop is for:* This workshop is aimed at Platform Engineers, DevOps Engineers, CLoud Operations, Architects, and Developers that wnat to learn what makes a modern application platform, and how they can leverage cloud services to streamline the delivery and operations of their application platforms.
+*Who this workshop is for:* This workshop is aimed at Platform Engineers, DevOps Engineers, Cloud Operations, Architects, and Developers that want to learn what makes a modern application platform, and how they can leverage cloud services to streamline the delivery and operations of their application platforms.
 
 *What to expect:* During the workshop, attendees will learn how to build a modern application platform by leveraging Azure Red Hat OpenShift, and other Azure cloud services. Through a series of hands on modules and instructor led presentations, attendees will:
 


### PR DESCRIPTION
**Overview of changes**

Home

- Capitalization typo

100-setup

- 1b references a broken image link
- align-center shows up literally as {align-center} in workshop content
- "To learn more about cluster authentication..." is stated twice
- Updates to version references

200-ops

- Fix broken link to OpenShift Update Service
- Grafana lab is missing a step to wait for Grafana deployment to successfully deploy before retrieving and accessing its route.  This should definitely be fixed because later steps indicate that a race condition may result in failed access and participants may confuse a pending deployment with this issue.
- Miscellaneous typos, wordsmithing, and version references